### PR TITLE
fix: passing null as first param to find() no longer throws

### DIFF
--- a/sinks.js
+++ b/sinks.js
@@ -6,7 +6,7 @@ function prop (key) {
   return (
     'string' == typeof key
     ? function (data) { return data[key] }
-    : 'object' === typeof key && 'function' === typeof key.exec //regexp
+    : key && 'object' === typeof key && 'function' === typeof key.exec //regexp
     ? function (data) { var v = map.exec(data); return v && v[0] }
     : key || id
   )

--- a/test/find.js
+++ b/test/find.js
@@ -67,3 +67,14 @@ test('there can only be one', function (t) {
   )
 
 })
+
+test('find null', function (t) {
+  pull(
+    pull.values([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    pull.find(null, function (err, first) {
+      t.equal(first, 1)
+      t.notOk(err)
+      t.end()
+    })
+  )
+})


### PR DESCRIPTION
Fixes a bug in which calling `pull.find(null, ...)` would throw