### PR TITLE
Update .travis.yml for newer Node versions, dropping old ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - 0.6
-  - 0.8
   - 0.12
   - 4
   - 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
   - 0.6
   - 0.8
+  - 0.12
+  - 4
+  - 5


### PR DESCRIPTION
It [seems](http://travis-ci.org/dominictarr/pull-stream) you don't have Travis set up for this anymore, but I forked, [tried it on Travis](https://travis-ci.org/anko/pull-stream/builds/122129628) and it passed nicely For Node ≥0.12, so here's that if you want to enable it.

[Failed on 0.6 and 0.8 though](https://travis-ci.org/anko/pull-stream/builds/122129437), but who cares right?